### PR TITLE
Implement partial support for Pi-hole V6

### DIFF
--- a/us.johnholbrook.pihole.sdPlugin/code.js
+++ b/us.johnholbrook.pihole.sdPlugin/code.js
@@ -120,6 +120,7 @@ function enable(context){
 function pollPihole(context){
     let { settings, session } = instances[context];
     getBlockingStatus(settings, session, response => {
+        // log(`response: ${JSON.stringify(response)}`)
         if ("error" in response){ // couldn't reach p-h, display a warning
             // log(`${instances[context].action} error`)
             send({
@@ -217,9 +218,10 @@ function writeSettings(context, action, settings){
             log(response);
         } else {
             instances[context].session = response.session;
-            instances[context].poller = setInterval(pollPihole, Math.ceil(response.took), context);
+            // instances[context].poller = setInterval(pollPihole, Math.ceil(response.took), context);
+            instances[context].poller = setInterval(pollPihole, 60000, context);
         }
-        log(JSON.stringify(instances));
+        // log(JSON.stringify(instances));
     });
 }
 
@@ -244,7 +246,7 @@ function connectElgatoStreamDeckSocket(inPort, inPluginUUID, inRegisterEvent, in
         let context = jsonObj.context;
 
         // log(`${action} ${event}`);
-        console.log(`${action} ${event}`);
+        // console.log(`${action} ${event}`);
 
         // update settings for this instance
         if (event == "didReceiveSettings"){

--- a/us.johnholbrook.pihole.sdPlugin/pi/index_pi.html
+++ b/us.johnholbrook.pihole.sdPlugin/pi/index_pi.html
@@ -16,8 +16,8 @@
             </div>
 
             <div class="sdpi-item">
-                <div class="sdpi-item-label">API Token</div>
-                <input type="text" class="sdpi-item-value" id="ph-key-input" value="" placeholder="Available in Pi-hole admin settings">
+                <div class="sdpi-item-label">Password</div>
+                <input type="password" class="sdpi-item-value" id="ph-key-input" value="" placeholder="Pi-hole admin password">
             </div>
 
             <div class="sdpi-item" id="disable-time">


### PR DESCRIPTION
This PR aims to take first steps of adding support for Pi-hole V6. The new API is documented [here](https://ftl.pi-hole.net/development-v6/docs/).

I've tested all of the actions (Disable, Enable, Temporarily Disable, & Toggle) and they should work. However the option to show stats has not been ported - this will require significant refactoring since V6 has no direct equivalent to the `summaryRaw` API, and I don't plan to tackle that in this PR.

Instead of authenticating with an API key for all requests, V6 requires calling an auth endpoint to obtain a token before other endpoints can be called. To accommodate this, I've added code that runs at plug-in startup to connect to Pi-hole with an app password and store the returned token in a reusable session object.