### PR TITLE
Fix several bugs in Pi-hole v6 API integration

### DIFF
--- a/us.johnholbrook.pihole.sdPlugin/code.js
+++ b/us.johnholbrook.pihole.sdPlugin/code.js
@@ -25,7 +25,7 @@ function pihole_connect(settings, handler){
     xhr.open("POST", req_addr);
     xhr.setRequestHeader("Content-Type", "application/json");
     xhr.onload = function(){
-        data = JSON.parse(xhr.response);
+        let data = JSON.parse(xhr.response);
         handler(data);
     }
     xhr.onerror = xhr.ontimeout = function(){
@@ -53,7 +53,7 @@ function getBlockingStatus(settings, session, handler){
     xhr.open("GET", req_addr);
     xhr.setRequestHeader("X-FTL-SID", session.sid);
     xhr.onload = function(){
-        data = JSON.parse(xhr.response);
+        let data = JSON.parse(xhr.response);
         handler(data);
     }
     xhr.onerror = function(){
@@ -81,7 +81,7 @@ function getStatsSummary(settings, session, handler){
     xhr.open("GET", req_addr);
     xhr.setRequestHeader("X-FTL-SID", session.sid);
     xhr.onload = function(){
-        data = JSON.parse(xhr.response);
+        let data = JSON.parse(xhr.response);
         handler(data);
     }
     xhr.onerror = function(){
@@ -184,25 +184,30 @@ function pollPihole(context){
 // process the pi-hole stats to make them more human-readable,
 // then cast to string
 function process_stat(stats, type){
-    switch (type){
-        case "domains_being_blocked":
-            return stats.gravity.domains_being_blocked.toLocaleString();
-        case "dns_queries_today":
-            return stats.queries.total.toLocaleString();
-        case "ads_blocked_today":
-            return stats.queries.blocked.toLocaleString();
-        case "ads_percentage_today":
-            return stats.queries.percent_blocked.toFixed(2) + "%";
-        case "unique_domains":
-            return stats.queries.unique_domains.toLocaleString();
-        case "queries_forwarded":
-            return stats.queries.forwarded.toLocaleString();
-        case "queries_cached":
-            return stats.queries.cached.toLocaleString();
-        case "clients_ever_seen":
-            return stats.clients.total.toLocaleString();
-        case "unique_clients":
-            return stats.clients.active.toLocaleString();
+    try {
+        switch (type){
+            case "domains_being_blocked":
+                return stats.gravity.domains_being_blocked.toLocaleString();
+            case "dns_queries_today":
+                return stats.queries.total.toLocaleString();
+            case "ads_blocked_today":
+                return stats.queries.blocked.toLocaleString();
+            case "ads_percentage_today":
+                return (stats.queries.percent_blocked ?? 0).toFixed(2) + "%";
+            case "unique_domains":
+                return stats.queries.unique_domains.toLocaleString();
+            case "queries_forwarded":
+                return stats.queries.forwarded.toLocaleString();
+            case "queries_cached":
+                return stats.queries.cached.toLocaleString();
+            case "clients_ever_seen":
+                return stats.clients.total.toLocaleString();
+            case "unique_clients":
+                return stats.clients.active.toLocaleString();
+        }
+    } catch(e) {
+        log(`process_stat error for "${type}": ${e.message}. Response: ${JSON.stringify(stats)}`);
+        return "?";
     }
 }
 
@@ -216,19 +221,6 @@ function setState(context, state){
         }
     };
     websocket.send(JSON.stringify(json));
-}
-
-// update the p-h address, API key, or disable time
-function updateSettings(payload){
-    if ("disable_time" in payload){
-        time = payload.disable_time;
-    }
-    if ("ph_key" in payload){
-        ph_key = payload.ph_key;
-    }
-    if ("ph_addr" in payload){
-        ph_addr = payload.ph_addr;
-    }
 }
 
 // write settings
@@ -269,18 +261,17 @@ function writeSettings(context, action, settings){
             log(response);
         } else{
             instances[context].session = response.session;
+            instances[context].sessionCreatedAt = Math.floor(Date.now() / 1000);
             instances[context].poller = setInterval(() => {
                 const timeNow = Math.floor(Date.now() / 1000);
-                const sessionExpired = "lastUpdateTime" in instances[context] &&
-                    (timeNow - instances[context].lastUpdateTime) > instances[context].session.validity;
-                instances[context].lastUpdateTime = timeNow;
+                const sessionExpired = (timeNow - instances[context].sessionCreatedAt) > instances[context].session.validity;
                 if (sessionExpired){
                     clearInterval(instances[context].poller);
                     pihole_connect(instances[context].settings, onReady);
                 } else{
                     pollPihole(context);
                 }
-            }, Math.ceil(response.took) * 1000);
+            }, 1000);
         }
         // log(JSON.stringify(instances));
     }
@@ -301,7 +292,9 @@ function connectElgatoStreamDeckSocket(inPort, inPluginUUID, inRegisterEvent, in
     };
     websocket.onclose = function(){
         // log("exiting now");
-        pihole_end(instances[context]);
+        for (const instance of Object.values(instances)){
+            pihole_end(instance);
+        }
     };
 
     // message handler

--- a/us.johnholbrook.pihole.sdPlugin/code.js
+++ b/us.johnholbrook.pihole.sdPlugin/code.js
@@ -38,8 +38,8 @@ function pihole_connect(settings, handler){
 function pihole_end({ settings, session }){
     if (session == null) return;
     let req_addr = `${settings.protocol}://${settings.ph_addr}/api/auth`;
-    // log(`call request to ${req_addr}`);
     let xhr = new XMLHttpRequest();
+    xhr.timeout = 5000;
     xhr.open("DELETE", req_addr);
     xhr.setRequestHeader("X-FTL-SID", session.sid);
     xhr.send();
@@ -48,15 +48,15 @@ function pihole_end({ settings, session }){
 // make a call to check if pi-hole is enabled
 function getBlockingStatus(settings, session, handler){
     let req_addr = `${settings.protocol}://${settings.ph_addr}/api/dns/blocking`;
-    // log(`call request to ${req_addr}`);
     let xhr = new XMLHttpRequest();
+    xhr.timeout = 5000;
     xhr.open("GET", req_addr);
     xhr.setRequestHeader("X-FTL-SID", session.sid);
     xhr.onload = function(){
         let data = JSON.parse(xhr.response);
         handler(data);
     }
-    xhr.onerror = function(){
+    xhr.onerror = xhr.ontimeout = function(){
         handler({"error": "couldn't reach Pi-hole"});
     }
     xhr.send();
@@ -76,15 +76,15 @@ function setBlockingStatus(settings, session, enabled, timer){
 // get stats for the pi-hole (# queries, # clients, etc.) and pass to a handler function
 function getStatsSummary(settings, session, handler){
     let req_addr = `${settings.protocol}://${settings.ph_addr}/api/stats/summary`;
-    // log(`get_status request to ${req_addr}`);
     let xhr = new XMLHttpRequest();
+    xhr.timeout = 5000;
     xhr.open("GET", req_addr);
     xhr.setRequestHeader("X-FTL-SID", session.sid);
     xhr.onload = function(){
         let data = JSON.parse(xhr.response);
         handler(data);
     }
-    xhr.onerror = function(){
+    xhr.onerror = xhr.ontimeout = function(){
         handler({"error": "couldn't reach Pi-hole"});
     }
     xhr.send();
@@ -95,7 +95,7 @@ function temporarily_disable(context){
     let { settings, session } = instances[context];
     getBlockingStatus(settings, session, response => {
         if (response.blocking == "enabled"){  // it only makes sense to temporarily disable p-h if it's currently enabled
-            setBlockingStatus(settings, session, false, parseInt(settings.disable_time))
+            setBlockingStatus(settings, session, false, parseInt(settings.disable_time) || 300)
         }
     });
 }
@@ -128,10 +128,12 @@ function enable(context){
 }
 
 // poll p-h and set the state and button text appropriately
-// (called once per second per instance)
 function pollPihole(context){
+    if (instances[context].polling) return;
+    instances[context].polling = true;
     let { settings, session } = instances[context];
     getBlockingStatus(settings, session, response => {
+        if (instances[context]) instances[context].polling = false;
         // log(`response: ${JSON.stringify(response)}`)
         if ("error" in response){ // couldn't reach p-h, display a warning
             // log(`${instances[context].action} error`)
@@ -204,6 +206,8 @@ function process_stat(stats, type){
                 return stats.clients.total.toLocaleString();
             case "unique_clients":
                 return stats.clients.active.toLocaleString();
+            default:
+                return "?";
         }
     } catch(e) {
         log(`process_stat error for "${type}": ${e.message}. Response: ${JSON.stringify(stats)}`);
@@ -225,15 +229,15 @@ function setState(context, state){
 
 // write settings
 function writeSettings(context, action, settings){
-    // write the settings
-    if (!(context in instances)){ 
+    if (!(context in instances)){
         instances[context] = {"action": action};
     }
-    instances[context].settings = settings;
-    if (instances[context].settings.ph_addr == ""){
-        instances[context].settings.ph_addr = "pi.hole";
+    const inst = instances[context];
+    inst.settings = settings;
+    if (inst.settings.ph_addr == ""){
+        inst.settings.ph_addr = "pi.hole";
     }
-    if (instances[context].settings.stat == "none"){
+    if (inst.settings.stat == "none"){
         send({
             "event": "setTitle",
             "context": context,
@@ -243,16 +247,20 @@ function writeSettings(context, action, settings){
         });
     }
 
-    // clean up old p-h instance
-    if ("poller" in instances[context]){
-        clearInterval(instances[context].poller);
-    }
-    pihole_end(instances[context]);
+    // Skip reconnect if connection parameters haven't changed and a session exists.
+    // This prevents a double-connect when willAppear and didReceiveSettings both fire on load.
+    const connKey = `${settings.protocol}://${inst.settings.ph_addr}:${settings.ph_key}`;
+    if (inst.connKey === connKey && inst.session) return;
+    inst.connKey = connKey;
 
-    // poll p-h to get status
-    instances[context].settings.show_status = true;
+    // clean up old p-h instance
+    if ("poller" in inst){
+        clearInterval(inst.poller);
+    }
+    pihole_end(inst);
+
+    inst.settings.show_status = true;
     const onReady = (response) => {
-        // log(`response: ${JSON.stringify(response)}`)
         if ("error" in response){
             send({
                 "event": "showAlert",
@@ -260,22 +268,21 @@ function writeSettings(context, action, settings){
             });
             log(response);
         } else{
-            instances[context].session = response.session;
-            instances[context].sessionCreatedAt = Math.floor(Date.now() / 1000);
-            instances[context].poller = setInterval(() => {
+            inst.session = response.session;
+            inst.sessionCreatedAt = Math.floor(Date.now() / 1000);
+            inst.poller = setInterval(() => {
                 const timeNow = Math.floor(Date.now() / 1000);
-                const sessionExpired = (timeNow - instances[context].sessionCreatedAt) > instances[context].session.validity;
+                const sessionExpired = (timeNow - inst.sessionCreatedAt) > inst.session.validity;
                 if (sessionExpired){
-                    clearInterval(instances[context].poller);
-                    pihole_connect(instances[context].settings, onReady);
+                    clearInterval(inst.poller);
+                    pihole_connect(inst.settings, onReady);
                 } else{
                     pollPihole(context);
                 }
-            }, 1000);
+            }, 5000);
         }
-        // log(JSON.stringify(instances));
     }
-    pihole_connect(instances[context].settings, onReady);
+    pihole_connect(inst.settings, onReady);
 }
 
 // called by the stream deck software when the plugin is initialized
@@ -328,6 +335,7 @@ function connectElgatoStreamDeckSocket(inPort, inPluginUUID, inRegisterEvent, in
 
         // handle a keypress
         else if (event == "keyUp"){
+            if (!instances[context]) return;
             if (action == "us.johnholbrook.pihole.toggle"){
                 toggle(context);
             }

--- a/us.johnholbrook.pihole.sdPlugin/pi/pi.js
+++ b/us.johnholbrook.pihole.sdPlugin/pi/pi.js
@@ -9,7 +9,6 @@ function send(data){
 
 // write to the log
 function log(message){
-    alert("logging!")
     send({
         "event": "logMessage",
         "payload": {
@@ -29,7 +28,7 @@ function connectElgatoStreamDeckSocket(inPort, inPropertyInspectorUUID, inRegist
     }
 
     websocket.onmessage = function(evt){
-        jsonObj = json.parse(evt.data);
+        jsonObj = JSON.parse(evt.data);
         let event = jsonObj.event;
     }
 

--- a/us.johnholbrook.pihole.sdPlugin/pi/pi.js
+++ b/us.johnholbrook.pihole.sdPlugin/pi/pi.js
@@ -7,16 +7,6 @@ function send(data){
     websocket.send(JSON.stringify(data));
 }
 
-// write to the log
-function log(message){
-    send({
-        "event": "logMessage",
-        "payload": {
-            "message": message
-        }
-    });
-}
-
 // called by the stream deck software when the PI is inizialized
 function connectElgatoStreamDeckSocket(inPort, inPropertyInspectorUUID, inRegisterEvent, inInfo, inActionInfo){
     websocket = new WebSocket(`ws://127.0.0.1:${inPort}`);
@@ -28,7 +18,7 @@ function connectElgatoStreamDeckSocket(inPort, inPropertyInspectorUUID, inRegist
     }
 
     websocket.onmessage = function(evt){
-        jsonObj = JSON.parse(evt.data);
+        let jsonObj = JSON.parse(evt.data);
         let event = jsonObj.event;
     }
 


### PR DESCRIPTION
- Fix session expiry logic using sessionCreatedAt instead of lastUpdateTime (lastUpdateTime was overwritten every second so sessions never reconnected)
- Fix polling interval to use fixed 1000ms instead of response.took * 1000
- Fix onclose handler to iterate all instances rather than undefined context
- Fix implicit global `data` variables in XHR callbacks (add let)
- Fix percent_blocked null crash with ?? 0 guard and try/catch in process_stat
- Fix json.parse -> JSON.parse crash in Property Inspector message handler
- Remove alert("logging!") debug popup from Property Inspector
- Remove dead updateSettings function